### PR TITLE
Add CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: build
+on: [push]
+jobs:
+    run-build:
+        runs-on: windows-latest
+        steps:
+            - uses: actions/checkout@v2
+            - run: git submodule update --init --recursive
+            - run: vcpkg integrate install
+            - name: Build
+              run: |
+                Remove-Item build -Recurse -Force -ErrorAction:SilentlyContinue -Confirm:$False | Out-Null;
+                cmake -B build -S Plugin --preset=REL -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake;
+                cmake --build build --config Release
+            - name: 'Upload Artifact'
+              uses: actions/upload-artifact@v3
+              with:
+                name: Release
+                path: build/Release
+                retention-days: 30


### PR DESCRIPTION
Added CI build to the template.

The intention here is to encourage developers to publish buildable sources that don't require some esoteric, undocumented setup.

This PR probably has to be rebased/picked onto other branches as well