### PR TITLE
Release ASI mods into the /Plugins directory

### DIFF
--- a/Plugin/dist/rules/publish_package.json
+++ b/Plugin/dist/rules/publish_package.json
@@ -1,12 +1,37 @@
 [
+	{
+        "action": "copy",
+        "params": [
+            "{dist}\\*.asi",
+            "{dist}\\Plugins\\"
+        ]
+    },
+	{
+        "action": "copy_if",
+        "params": [
+            "{dist}\\*.ini",
+            "{dist}\\Plugins\\"
+        ]
+    },
+	{
+        "action": "copy_if",
+        "params": [
+            "{dist}\\*.json",
+            "{dist}\\Plugins\\"
+        ]
+    },
+	{
+        "action": "copy_if",
+        "params": [
+            "{dist}\\*.toml",
+            "{dist}\\Plugins\\"
+        ]
+    },
     {
         "action": "package",
         "config": "Release",
         "params": [
-            "{dist}\\*.asi",
-            "{dist}\\*.ini",
-            "{dist}\\*.json",
-            "{dist}\\*.toml",
+            "{dist}\\Plugins\\",
             "{dist}\\{project_name}.v{project_version}.zip"
         ]
     },
@@ -14,11 +39,7 @@
         "action": "package",
         "config": "RelWithDebInfo",
         "params": [
-            "{dist}\\*.asi",
-            "{dist}\\*.pdb",
-            "{dist}\\*.ini",
-            "{dist}\\*.json",
-            "{dist}\\*.toml",
+            "{dist}\\Plugins\\",
             "{dist}\\{project_name}.v{project_version}.zip"
         ]
     }


### PR DESCRIPTION
The ASI Loader loads .asi files from the game root directory, but also from other sources like the /Plugins directory.  
I saw most mod authors who released an ASI version of their mods, putting them into the Plugins directory and I do it as well.  
It's definitely better organized there than in the game root, especially if the mod create a log and a config file in the same place as well.  
